### PR TITLE
Make paired reader/writer sets thread safe

### DIFF
--- a/pair.go
+++ b/pair.go
@@ -40,6 +40,16 @@ func NewPair(path string) (*PairedReader, *PairedWriter, error) {
 
 var ErrNoData = errors.New("no data available")
 
+// Next wraps the underlying WALReader's Next() method with a
+// mutex which is shared by the writer. Since we are dealing
+// with file IO, a simple mutex makes it safe for a paired
+// reader and writer to run concurrently.
+func (r *PairedReader) Next() bool {
+	r.pw.lock.Lock()
+	defer r.pw.lock.Unlock()
+	return r.WALReader.Next()
+}
+
 func (r *PairedReader) BlockingNext() error {
 	r.pw.lock.Lock()
 
@@ -60,12 +70,12 @@ func (r *PairedReader) BlockingNext() error {
 }
 
 func (r *PairedWriter) Write(d []byte) error {
+	r.lock.Lock()
+
 	err := r.WALWriter.Write(d)
 	if err != nil {
 		return err
 	}
-
-	r.lock.Lock()
 
 	r.gen++
 

--- a/pair_test.go
+++ b/pair_test.go
@@ -1,9 +1,12 @@
 package wal
 
 import (
+	"bytes"
+	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,6 +74,57 @@ func TestPair(t *testing.T) {
 		require.NoError(t, r.BlockingNext())
 
 		assert.Equal(t, []byte("data1"), r.Value())
+	})
+
+	n.It("linearizes reads and writes", func() {
+		r, w, err := NewPair(path)
+		require.NoError(t, err)
+
+		// Create a ton of input messages to write
+		in := make([][]byte, 10240)
+		for i := 0; i < len(in); i++ {
+			in[i] = make([]byte, 128)
+			_, err := rand.Read(in[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Write all of the messages in the background
+		go func() {
+			defer wg.Done()
+			for _, p := range in {
+				if err := w.Write(p); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}()
+
+		// In a separate goroutine, try reading a bunch of messages.
+		// Since we can't really tell how fast the writer is going,
+		// we'll just make sure that the reads we do get line up
+		// correctly with what we expect.
+		go func() {
+			defer wg.Done()
+			for i := 0; i < len(in); i++ {
+				if !r.Next() {
+					if err := r.Error(); err != nil {
+						t.Fatal(err)
+					}
+					i--
+					continue
+				}
+
+				if !bytes.Equal(r.Value(), in[i]) {
+					t.Fatal("mismach found, probably a race: %v")
+				}
+			}
+		}()
+
+		wg.Wait()
 	})
 
 	n.Meow()

--- a/pair_test.go
+++ b/pair_test.go
@@ -119,7 +119,7 @@ func TestPair(t *testing.T) {
 				}
 
 				if !bytes.Equal(r.Value(), in[i]) {
-					t.Fatal("mismach found, probably a race: %v")
+					t.Fatal("mismach found, probably a race")
 				}
 			}
 		}()


### PR DESCRIPTION
Fixes a nasty bug where a disjoint reader/writer get offset skew when reading a file which is only partially written. This surfaced up in Cypress where we use the WALReader and WALWriter completely independent of one another, but the thinking is we solve this problem down here in the paired reader/writer and start using that with the normal, non-blocking `Next()` up in Cypress.

Tests before (shows exact error we see in Cypress):

```
--- FAIL: TestPair (2.73s)
    neko.go:109: Meow! Neko is on the case! Running 4 tests now!
    neko.go:81: ==== exposes writes in the reader ====
    neko.go:81: ==== blocks waiting for more data ====
    neko.go:81: ==== only blocks when there is no more data ====
    neko.go:81: ==== linearizes reads and writes ====
    pair_test.go:115: corrupt data detected
```

Tests after:

```
PASS
ok      github.com/evanphx/wal  2.831s
```
